### PR TITLE
1.2.1

### DIFF
--- a/maps/LancesRoom.asm
+++ b/maps/LancesRoom.asm
@@ -89,6 +89,8 @@ LancesRoomLanceScript:
 	readvar VAR_BADGES
 	if_less_than 9, .BaseCap
 	if_not_equal 16, .DontUpdateBadge
+	checkevent EVENT_CERULEAN_CAVE_B1F_MEWTWO
+	iftrue .DontUpdateBadge
 	loadmem wLevelCap, 77 ; update level cap for hard mode
 	sjump .DontUpdateBadge
 .BaseCap

--- a/maps/SilverCaveRoom3.asm
+++ b/maps/SilverCaveRoom3.asm
@@ -67,6 +67,10 @@ Red:
 	pause 30
 	special HealParty
 	refreshscreen
+	checkflag ENGINE_HARD_MODE
+	iffalse .NotHardMode1
+	loadmem wLevelCap, 100 ; update level cap for hard mode
+.NotHardMode1
 	credits
 	end
 


### PR DESCRIPTION
fixed a bug where the E4 rematch would set your level cap back to 77 if fought after red